### PR TITLE
adding cb-enterprise as requirement in rpm spec file

### DIFF
--- a/python-cbisight-connector.spec
+++ b/python-cbisight-connector.spec
@@ -18,6 +18,7 @@ Prefix: %{_prefix}
 BuildArch: x86_64
 Vendor: Carbon Black
 Url: http://www.carbonblack.com/
+Requires: cb-enterprise >= 5.0
 
 %description
 UNKNOWN


### PR DESCRIPTION
We want to add the cb-enterprise requirement in the spec file.  This rpm requires a Carbon Black server for installation.
